### PR TITLE
Fix bwe-mem-pe.cwl

### DIFF
--- a/job/bwa-mapping-pe.yml
+++ b/job/bwa-mapping-pe.yml
@@ -1,0 +1,4 @@
+nthreads: 2 # default value of type "int". (optional)
+fastq1_url: https://github.com/suecharo/test-workflow/raw/master/data/small.ERR034597_1.fastq # type "string"
+fastq2_url: https://github.com/suecharo/test-workflow/raw/master/data/small.ERR034597_2.fastq # type "string"
+fasta_url: https://github.com/suecharo/test-workflow/raw/master/data/small.chr22.fa # type "string"

--- a/tool/bwa_mem_pe.cwl
+++ b/tool/bwa_mem_pe.cwl
@@ -5,6 +5,20 @@ requirements:
   InlineJavascriptRequirement: {}
   DockerRequirement:
     dockerPull: quay.io/biocontainers/bwa:0.7.15--1
+  InitialWorkDirRequirement:
+    listing:
+      - entry: $(inputs.fasta)
+        entryname: $(inputs.fasta.basename)
+      - entry: $(inputs.amb)
+        entryname: $(inputs.amb.basename)
+      - entry: $(inputs.ann)
+        entryname: $(inputs.ann.basename)
+      - entry: $(inputs.bwt)
+        entryname: $(inputs.bwt.basename)
+      - entry: $(inputs.pac)
+        entryname: $(inputs.pac.basename)
+      - entry: $(inputs.sa)
+        entryname: $(inputs.sa.basename)
 
 baseCommand: [bwa, mem, -K, "100000000", -Y, -p]
 arguments:
@@ -19,12 +33,6 @@ inputs:
       prefix: -t
   fasta:
     type: File
-    secondaryFiles:
-      - $(inputs.amb)
-      - $(inputs.ann)
-      - $(inputs.bwt)
-      - $(inputs.pac)
-      - $(inputs.sa)
   amb:
     type: File
   ann:


### PR DESCRIPTION
This request makes `bwe-mem-pe.cwl` workable by using `InitialWorkDirRequirement` instead of using `secondaryFiles`.
